### PR TITLE
Fix sessions timing out

### DIFF
--- a/view.html.erb
+++ b/view.html.erb
@@ -1,5 +1,12 @@
-<script>
-  document.cookie = "csrf-token=<%= csrf_token %>; path=/rnode/<%= host %>/<%= port %>; secure";
+<script type="text/javascript">
+(function () {
+  let date = new Date();
+  date.setTime(date.getTime() + (7*24*60*60*1000));
+  let expires = "expires=" + date.toUTCString();
+  let cookiePath = "path=/rnode/" + "<%= host.to_s %>" + "/" + "<%= port.to_s %>/";
+  let cookie = `csrf-token=<%= csrf_token %>;${expires};${cookiePath};SameSite=strict;secure`;
+  document.cookie = cookie;
+})();
 </script>
 <form action="/rnode/<%= host %>/<%= port %>/auth-do-sign-in" method="post" target="_blank">
   <input type="hidden" name="username" value="<%= ENV["USER"] %>">


### PR DESCRIPTION
## Issue

After a few hours from launching an RStudio session, it appears to expire. When this happens, clicking on "Connect to RStudio Server" for the RStudio Server Launcher job in Open OnDemand, this page appears:

![Screenshot 2023-07-27 at 11-59-42 Error RStudio Sign In Failed](https://github.com/mcw-rcc/bc_rcc_rstudio_server/assets/7016957/85d78872-d475-4481-8660-6604936993d7)

At the same time, this line is logged on the server running Open OnDemand:

```
ERROR Failed to validate sign-in with invalid CSRF form; LOGGED FROM: bool rstudio::server::auth::common::validateSignIn(const rstudio::core::http::Request&, rstudio::core::http::Response*) src/cpp/server/auth/ServerAuthCommon.cpp:133
```

## Solution

In troubleshooting this issue, I noticed the repo in which this one was based[^1], in the commit related to the most recent CSRF changes, that one part of the commit from this repo[^2] differed to theirs[^3].

This part is the `<script>` portion of the `view.html.erb`. Once I replaced this block of code for this repo, the issue described above no longer occurred. I tested this numerous times to confirm.

## Environment

**RStudio Server:** 2023.03.0 Build 386
**Open OnDemand:** 2.0.32

[^1]: https://github.com/OSC/bc_osc_rstudio_server
[^2]: https://github.com/mcw-rcc/bc_rcc_rstudio_server/commit/24e618654dc956ab901b52495f346b82845ea0ba
[^3]: https://github.com/OSC/bc_osc_rstudio_server/commit/1f26f2856f294d9e9be7782bd53b1fd085170e0c